### PR TITLE
pr-sync: use service account for approving PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,8 +21,9 @@ jobs:
     if: ${{ github.event.pull_request || github.event.issue.pull_request }}
 
     steps:
-      - uses: backstage/actions/pr-sync@v0.4.0
+      - uses: backstage/actions/pr-sync@v0.5.0
         with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN  }}
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "test:dev": "nodemon --ext js,ts test/entry.js",
     "test": "yarn jest"

--- a/pr-sync/action.yml
+++ b/pr-sync/action.yml
@@ -1,6 +1,9 @@
 name: Backstage PR Sync
 description: Action to sync Backstage PR tracking
 inputs:
+  github-token:
+    description: The GitHub account token to use for posting reviews
+    required: true
   app-id:
     description: The Application ID of the GitHub App to use for authentication
     required: true

--- a/pr-sync/index.ts
+++ b/pr-sync/index.ts
@@ -23,7 +23,9 @@ async function main() {
   const projectId = core.getInput('project-id', { required: true });
   const excludedUsers = core.getInput('excluded-users', { required: false });
   const owningTeams = core.getInput('owning-teams', { required: false });
+  const token = core.getInput('github-token', { required: true });
 
+  const userClient = github.getOctokit(token);
   const client = createAppClient();
 
   const owningTeam = await getPrOwner(
@@ -50,9 +52,13 @@ async function main() {
   };
 
   await Promise.all([
-    syncProjectBoard(client, commonOptions, mkLog('approve-renovate-prs')),
+    syncProjectBoard(client, commonOptions, mkLog('sync-project-board')),
     randomAssign(client, commonOptions, mkLog('random-assign')),
-    approveRenovatePRs(client, commonOptions, mkLog('approve-renovate-prs')),
+    approveRenovatePRs(
+      userClient,
+      commonOptions,
+      mkLog('approve-renovate-prs'),
+    ),
   ]);
 }
 


### PR DESCRIPTION
GitHub apps can't be codeowners, so we still need the service account to approve PRs