### PR TITLE
pr-sync: set changed timestamp when added to the board

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event.pull_request || github.event.issue.pull_request }}
 
     steps:
-      - uses: backstage/actions/pr-sync@v0.5.0
+      - uses: backstage/actions/pr-sync@v0.5.3
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN  }}
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.2",
+  "version": "0.5.3",
   "scripts": {
     "test:dev": "nodemon --ext js,ts test/entry.js",
     "test": "yarn jest"

--- a/pr-sync/syncProjectBoard.test.ts
+++ b/pr-sync/syncProjectBoard.test.ts
@@ -56,11 +56,20 @@ describe('syncProjectBoard', () => {
               id: 'field-2',
               name: 'Added',
             },
+            {
+              id: 'field-3',
+              name: 'Changed',
+            },
           ],
         },
       },
     });
 
+    mockClient.graphql.mockResolvedValueOnce({
+      projectV2Item: {
+        id: 'item-3',
+      },
+    });
     mockClient.graphql.mockResolvedValueOnce({
       projectV2Item: {
         id: 'item-3',

--- a/pr-sync/syncProjectBoard.ts
+++ b/pr-sync/syncProjectBoard.ts
@@ -73,13 +73,27 @@ async function addToBoard(
   if (!addedField) {
     throw new Error('Could not find "Added" field');
   }
+  const changedField = fields?.find(field => field?.name === 'Changed');
+  if (!changedField) {
+    throw new Error('Could not find "Changed" field');
+  }
 
-  await updateProjectV2FieldValue(client, {
-    projectId: options.projectId,
-    fieldId: addedField?.id,
-    itemId,
-    value: { text: new Date().toISOString().replace('T', ' ').slice(0, -5) },
-  });
+  const timestampText = new Date().toISOString().replace('T', ' ').slice(0, -5);
+
+  await Promise.all([
+    updateProjectV2FieldValue(client, {
+      projectId: options.projectId,
+      fieldId: addedField?.id,
+      itemId,
+      value: { text: timestampText },
+    }),
+    updateProjectV2FieldValue(client, {
+      projectId: options.projectId,
+      fieldId: changedField?.id,
+      itemId,
+      value: { text: timestampText },
+    }),
+  ]);
 
   if (options.owningTeam) {
     log(


### PR DESCRIPTION
So that sorting by changed timestamp makes more sense