### PR TITLE
bugfixes for changeset feedback action

### DIFF
--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -13,11 +13,17 @@ inputs:
     description: The target branch to use to list the changes
     default: origin/master
     required: false
+  issue-number:
+    description: issue number of the PR
+    required: true
   app-id:
     description: The Application ID of the GitHub App to use for authentication
     required: true
-  issue-number:
-    description: issue number of the PR
+  private-key:
+    description: The Private Key of the GitHub App to use for authentication
+    required: true
+  installation-id:
+    description: The Installation ID of the GitHub App to use for authentication
     required: true
 outputs: {}
 runs:

--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -13,6 +13,12 @@ inputs:
     description: The target branch to use to list the changes
     default: origin/master
     required: false
+  app-id:
+    description: The Application ID of the GitHub App to use for authentication
+    required: true
+  issue-number:
+    description: issue number of the PR
+    required: true
 outputs: {}
 runs:
   using: node16

--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -1,10 +1,6 @@
 name: Backstage Changeset Feedback
 description: Action to post the changeset feedback on a PR
 inputs:
-  github-token:
-    description: The GitHub token used to create an authenticated client
-    default: ${{ github.token }}
-    required: true
   marker:
     description: Marker to check if there is already a changeset posted on the PR
     default: '<!-- changeset-feedback -->'


### PR DESCRIPTION
- github token is not needed
- issue number, app-id, installation-id, private-key is needed for the bot to post on the PR
- Tested on this PR: https://github.com/djamaile/backstage/pull/1