### PR TITLE
[Changeset]: Make user login a parameter instead of hard coded

### DIFF
--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -12,6 +12,9 @@ inputs:
   issue-number:
     description: issue number of the PR
     required: true
+  userLogin:
+    description: login of the user that is posting the PR comment
+    required: true
   app-id:
     description: The Application ID of the GitHub App to use for authentication
     required: true

--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -14,7 +14,8 @@ inputs:
     required: true
   botUsername:
     description: username of the bot used to post comments on behalf of the action. Will be used when locating existing changeset feedback comments to update.
-    required: true
+    default: github-actions[bot]
+    required: false
   app-id:
     description: The Application ID of the GitHub App to use for authentication
     required: true

--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -12,8 +12,8 @@ inputs:
   issue-number:
     description: issue number of the PR
     required: true
-  userLogin:
-    description: login of the user that is posting the PR comment
+  botUsername:
+    description: username of the bot used to post comments on behalf of the action. Will be used when locating existing changeset feedback comments to update.
     required: true
   app-id:
     description: The Application ID of the GitHub App to use for authentication

--- a/changeset-feedback/index.ts
+++ b/changeset-feedback/index.ts
@@ -17,6 +17,7 @@ async function main() {
   const marker = core.getInput('marker', { required: true });
   const diffRef = core.getInput('diffRef', { required: true });
   const issueNumberStr = core.getInput('issue-number', { required: true });
+  const userLogin = core.getInput('userLogin', {required: true});
   const changedFiles = await listChangedFiles(diffRef);
   const packages = await listPackages();
   const changesets = await loadChangesets(changedFiles);
@@ -31,6 +32,7 @@ async function main() {
     issueNumberStr,
     marker,
     feedback,
+    userLogin,
   });
 }
 

--- a/changeset-feedback/index.ts
+++ b/changeset-feedback/index.ts
@@ -17,7 +17,7 @@ async function main() {
   const marker = core.getInput('marker', { required: true });
   const diffRef = core.getInput('diffRef', { required: true });
   const issueNumberStr = core.getInput('issue-number', { required: true });
-  const userLogin = core.getInput('userLogin', {required: true});
+  const botUsername = core.getInput('botUsername', {required: true});
   const changedFiles = await listChangedFiles(diffRef);
   const packages = await listPackages();
   const changesets = await loadChangesets(changedFiles);
@@ -32,7 +32,7 @@ async function main() {
     issueNumberStr,
     marker,
     feedback,
-    userLogin,
+    botUsername,
   });
 }
 

--- a/changeset-feedback/postFeedback.test.ts
+++ b/changeset-feedback/postFeedback.test.ts
@@ -52,7 +52,7 @@ const repoInfo = {
   owner: 'le-owner',
   repo: 'le-repo',
 };
-const userLogin = 'github-actions[bot]';
+const botUsername = 'github-actions[bot]';
 const log = jest.fn();
 const marker = 'changeset-feedback';
 const body = (feedback: string) =>
@@ -82,7 +82,7 @@ describe('changeset feedback', () => {
 
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker, feedback, userLogin },
+      { ...repoInfo, issueNumberStr: '1', marker, feedback, botUsername },
       log,
     );
     expect(mockClient.rest.issues.createComment).toHaveBeenCalledWith({
@@ -97,7 +97,7 @@ describe('changeset feedback', () => {
     mockClient.paginate.mockResolvedValue(commentsWithFeedBack);
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker, feedback, userLogin },
+      { ...repoInfo, issueNumberStr: '1', marker, feedback, botUsername },
       log,
     );
     expect(mockClient.rest.issues.updateComment).not.toHaveBeenCalled();
@@ -110,7 +110,7 @@ describe('changeset feedback', () => {
     mockClient.paginate.mockResolvedValue(commentsWithFeedBack);
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker, feedback: feedbackUpdated, userLogin },
+      { ...repoInfo, issueNumberStr: '1', marker, feedback: feedbackUpdated, botUsername },
       log,
     );
     expect(log).toHaveBeenCalledWith('updating existing comment in #1');
@@ -125,7 +125,7 @@ describe('changeset feedback', () => {
     mockClient.paginate.mockResolvedValue(commentsWithFeedBack);
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker: '', feedback: '', userLogin },
+      { ...repoInfo, issueNumberStr: '1', marker: '', feedback: '', botUsername },
       log,
     );
     expect(mockClient.rest.issues.deleteComment).toHaveBeenCalledWith({

--- a/changeset-feedback/postFeedback.test.ts
+++ b/changeset-feedback/postFeedback.test.ts
@@ -52,6 +52,7 @@ const repoInfo = {
   owner: 'le-owner',
   repo: 'le-repo',
 };
+const userLogin = 'github-actions[bot]';
 const log = jest.fn();
 const marker = 'changeset-feedback';
 const body = (feedback: string) =>
@@ -81,7 +82,7 @@ describe('changeset feedback', () => {
 
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker, feedback },
+      { ...repoInfo, issueNumberStr: '1', marker, feedback, userLogin },
       log,
     );
     expect(mockClient.rest.issues.createComment).toHaveBeenCalledWith({
@@ -96,7 +97,7 @@ describe('changeset feedback', () => {
     mockClient.paginate.mockResolvedValue(commentsWithFeedBack);
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker, feedback },
+      { ...repoInfo, issueNumberStr: '1', marker, feedback, userLogin },
       log,
     );
     expect(mockClient.rest.issues.updateComment).not.toHaveBeenCalled();
@@ -109,7 +110,7 @@ describe('changeset feedback', () => {
     mockClient.paginate.mockResolvedValue(commentsWithFeedBack);
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker, feedback: feedbackUpdated },
+      { ...repoInfo, issueNumberStr: '1', marker, feedback: feedbackUpdated, userLogin },
       log,
     );
     expect(log).toHaveBeenCalledWith('updating existing comment in #1');
@@ -124,7 +125,7 @@ describe('changeset feedback', () => {
     mockClient.paginate.mockResolvedValue(commentsWithFeedBack);
     await postFeedback(
       client,
-      { ...repoInfo, issueNumberStr: '1', marker: '', feedback: '' },
+      { ...repoInfo, issueNumberStr: '1', marker: '', feedback: '', userLogin },
       log,
     );
     expect(mockClient.rest.issues.deleteComment).toHaveBeenCalledWith({

--- a/changeset-feedback/postFeedback.ts
+++ b/changeset-feedback/postFeedback.ts
@@ -9,11 +9,11 @@ export async function postFeedback(
     issueNumberStr: string;
     marker: string;
     feedback: string;
-    userLogin: string;
+    botUsername: string;
   },
   log = core.info,
 ) {
-  const { owner, repo, issueNumberStr, marker, feedback, userLogin } = options;
+  const { owner, repo, issueNumberStr, marker, feedback, botUsername } = options;
   const issue_number = Number(issueNumberStr);
   const body = feedback.trim() ? feedback + marker : undefined;
 
@@ -26,11 +26,8 @@ export async function postFeedback(
     },
   );
 
-  const { login } = await client.rest.users.user();
-  log(`user: ${login}`);
-
   const existingComment = existingComments.find(
-    c => c.user?.login === userLogin && c.body?.includes(marker),
+    c => c.user?.login === botUsername && c.body?.includes(marker),
   );
 
   if (existingComment) {

--- a/changeset-feedback/postFeedback.ts
+++ b/changeset-feedback/postFeedback.ts
@@ -26,6 +26,9 @@ export async function postFeedback(
     },
   );
 
+  const { login } = await client.rest.users.user();
+  log(`user: ${login}`);
+
   const existingComment = existingComments.find(
     c => c.user?.login === userLogin && c.body?.includes(marker),
   );

--- a/changeset-feedback/postFeedback.ts
+++ b/changeset-feedback/postFeedback.ts
@@ -9,10 +9,11 @@ export async function postFeedback(
     issueNumberStr: string;
     marker: string;
     feedback: string;
+    userLogin: string;
   },
   log = core.info,
 ) {
-  const { owner, repo, issueNumberStr, marker, feedback } = options;
+  const { owner, repo, issueNumberStr, marker, feedback, userLogin } = options;
   const issue_number = Number(issueNumberStr);
   const body = feedback.trim() ? feedback + marker : undefined;
 
@@ -26,7 +27,7 @@ export async function postFeedback(
   );
 
   const existingComment = existingComments.find(
-    c => c.user?.login === 'github-actions[bot]' && c.body?.includes(marker),
+    c => c.user?.login === userLogin && c.body?.includes(marker),
   );
 
   if (existingComment) {


### PR DESCRIPTION
The bot can have a different name per repository. So, it makes sense to have this dynamic.