### PR TITLE
use `getBooleanInput` otherwise it defaults to string

### DIFF
--- a/pr-sync/index.ts
+++ b/pr-sync/index.ts
@@ -25,7 +25,7 @@ async function main() {
   const owningTeams = core.getInput('owning-teams', { required: false });
   const token = core.getInput('github-token', { required: true });
   const shouldAutoAssign =
-    core.getInput('auto-assign', { required: false }) ?? true;
+    core.getBooleanInput('auto-assign', { required: false }) ?? true;
 
   const userClient = github.getOctokit(token);
   const client = createAppClient();


### PR DESCRIPTION
- chore: added ability to opt out of auto assignment
- chore: woops
