### PR TITLE
Ignore .changesets/README.md when generating changeset feedback

### DIFF
--- a/changeset-feedback/generateFeedback.ts
+++ b/changeset-feedback/generateFeedback.ts
@@ -122,7 +122,11 @@ export async function listPackages() {
 export async function loadChangesets(filePaths: string[]) {
   const changesets = [];
   for (const filePath of filePaths) {
-    if (!filePath.startsWith('.changeset/') || !filePath.endsWith('.md')) {
+    if (
+      !filePath.startsWith('.changeset/') ||
+      !filePath.endsWith('.md') ||
+      filePath.endsWith('README.md')
+    ) {
       continue;
     }
     try {


### PR DESCRIPTION
It's [expected](https://github.com/changesets/changesets/blob/5c53bff0efeb5bbd72976b79aefe9d5805038ebd/packages/cli/src/commands/init/index.ts#L67) that the .changeset directory will contain a README.md. Previously, the generateFeedback action would attempt to parse the README as a changeset. This PR ignores the file.

Note that I haven't tested this change!