### PR TITLE
fix(generateFeedback): remove reference to undefined attribute

### DIFF
--- a/changeset-feedback/generateFeedback.ts
+++ b/changeset-feedback/generateFeedback.ts
@@ -167,9 +167,7 @@ export async function listChangedPackages(
           break;
         }
         const entry = changedPackageMap.get(pkg.packageJson.name);
-        if (entry) {
-          entry.files.push(pkgPath);
-        } else {
+        if (!entry) {
           changedPackageMap.set(pkg.packageJson.name, {
             ...pkg,
             isStable: !pkg.packageJson.version.startsWith('0.'),


### PR DESCRIPTION
The `entry.files` attribute became undefined due to the previous change (https://github.com/backstage/actions/pull/147) and seems to be causing the failure in my PR (https://github.com/backstage/community-plugins/actions/runs/8824034639/job/24225729299?pr=351)

It also looks like this attribute is never used anywhere in this action so removed the undefined reference to it