### PR TITLE
chore: ignore root package.jsons

### DIFF
--- a/renovate-changesets/index.ts
+++ b/renovate-changesets/index.ts
@@ -83,7 +83,8 @@ async function main() {
     Array.from(changedFilesByWorkspace.entries())
       .map(([workspace, files]) => [
         workspace,
-        files.filter(f => f.endsWith('package.json')),
+        // Ignore root package.json from the workspace, and check for package.json in the subfolders
+        files.filter(f => f !== 'package.json' && f.endsWith('package.json')),
       ])
       .filter((workspaceChanges): workspaceChanges is [string, string[]] => {
         const [_, files] = workspaceChanges;


### PR DESCRIPTION
Need to ignore the root package dependency bumps, they're not deployable.

https://github.com/backstage/community-plugins/pull/194 vs https://github.com/backstage/community-plugins/pull/177