### PR TITLE
feat: Enable "renovate changeset" action to work with dependabot

### DIFF
--- a/renovate-changesets/action.yaml
+++ b/renovate-changesets/action.yaml
@@ -1,10 +1,14 @@
-name: Backstage Renovate Changeset Creator
-description: Create changesets on the renovate bot PR's if needed
+name: Backstage Dependency Manager Changeset Creator
+description: Create changesets on the dependency manager bot PR's if needed
 inputs:
   multiple-workspaces:
     description: If it's this repository is a collection of workspaces
     required: false
     default: 'false'
+  dependency-manager:
+    description: The dependency manager to use
+    required: false
+    default: 'renovate'
 
 outputs: {}
 runs:

--- a/renovate-changesets/dependencyConfig.ts
+++ b/renovate-changesets/dependencyConfig.ts
@@ -1,0 +1,17 @@
+import * as core from '@actions/core';
+
+export type DependencyMangerConfig = {
+  branchPrefix: string;
+  changesetPrefix: string;
+};
+
+export const dependencyMangerConfig: Record<string, DependencyMangerConfig> = {
+  renovate: { branchPrefix: 'renovate/', changesetPrefix: 'renovate' },
+  dependabot: { branchPrefix: 'dependabot/', changesetPrefix: 'dependabot' },
+};
+
+export const getDependencyManager = () => {
+  return core.getInput('dependency-manager', {
+    required: false,
+  });
+};

--- a/renovate-changesets/index.ts
+++ b/renovate-changesets/index.ts
@@ -7,11 +7,15 @@ import {
   getChangedFiles,
   getChangesetFilename,
   listPackages,
-} from './renovateChangesets';
+} from './manageChangesets';
 import { relative as relativePath, resolve as resolvePath } from 'path';
+import {
+  dependencyMangerConfig,
+  getDependencyManager,
+} from './dependencyConfig';
 
 async function main() {
-  core.info('Running Renovate Changesets');
+  core.info(`Running ${getDependencyManager()} Changesets`);
 
   const isMultipleWorkspaces = core.getBooleanInput('multiple-workspaces', {
     required: false,
@@ -19,8 +23,12 @@ async function main() {
 
   const branchName = await getBranchName();
 
-  if (!branchName.startsWith('renovate/')) {
-    core.info('Not a renovate branch, skipping');
+  if (
+    !branchName.startsWith(
+      dependencyMangerConfig[getDependencyManager()].branchPrefix,
+    )
+  ) {
+    core.info(`Not a ${getDependencyManager()} branch, skipping`);
     return;
   }
 

--- a/renovate-changesets/manageChangesets.ts
+++ b/renovate-changesets/manageChangesets.ts
@@ -2,6 +2,10 @@ import { getExecOutput, exec } from '@actions/exec';
 import fs from 'fs/promises';
 import { resolve as resolvePath, relative as relativePath } from 'path';
 import { getPackages, type Package } from '@manypkg/get-packages';
+import {
+  dependencyMangerConfig,
+  getDependencyManager,
+} from './dependencyConfig';
 
 export async function getBranchName() {
   const { stdout } = await getExecOutput('git', ['branch', '--show-current']);
@@ -34,7 +38,9 @@ export async function getChangesetFilename() {
   const { stdout: shortHash } = await getExecOutput(
     'git rev-parse --short HEAD',
   );
-  return `.changeset/renovate-${shortHash.trim()}.md`;
+  return `.changeset/${
+    dependencyMangerConfig[getDependencyManager()].changesetPrefix
+  }-${shortHash.trim()}.md`;
 }
 
 export async function createChangeset(


### PR DESCRIPTION
Add in the ability for the renovate changeset action to work with different dependency managers such as dependabot.

I needed/wanted to add this for our own plugins repo so thought it might be a worthwhile contribution.

I didnt go as far as renaming the action itself but that would make sense at some point (if this PR is accepted).