### PR TITLE
changeset-feedback: match all kind of API report names

### DIFF
--- a/changeset-feedback/generateFeedback.ts
+++ b/changeset-feedback/generateFeedback.ts
@@ -45,8 +45,9 @@ function isPublishedPath(path: string) {
   // API report changes by themselves don't count
   if (
     path === 'cli-report.md' ||
-    path === 'api-report.md' ||
-    path.endsWith('-api-report.md')
+    (path.includes('api-report') && path.endsWith('.md')) ||
+    path.endsWith('.api.md') ||
+    path.endsWith('.cli.md')
   ) {
     return false;
   }


### PR DESCRIPTION
Updating the changeset feedback action to take all kind of namings of the API report into account. In particular this fixed matching with for example `api-report-alpha.md`, but is also forwards compatible with the upcoming `.api.md` and potential `.cli.md` extensions.