### PR TITLE
chore: update renovateChangeset to skip changesets for devDependency-only updates

### DIFF
--- a/renovate-changesets/action.yaml
+++ b/renovate-changesets/action.yaml
@@ -5,10 +5,10 @@ inputs:
     description: If it's this repository is a collection of workspaces
     required: false
     default: 'false'
-  includeDevDependencies:
-    description: If devDependency changes should be included
+  excludeDevDependencies:
+    description: If devDependency changes should be excluded
     required: false
-    default: 'true'
+    default: 'false'
 
 outputs: {}
 runs:

--- a/renovate-changesets/action.yaml
+++ b/renovate-changesets/action.yaml
@@ -5,6 +5,10 @@ inputs:
     description: If it's this repository is a collection of workspaces
     required: false
     default: 'false'
+  includeDevDependencies:
+    description: If devDependency changes should be included
+    required: false
+    default: 'true'
 
 outputs: {}
 runs:

--- a/renovate-changesets/index.ts
+++ b/renovate-changesets/index.ts
@@ -124,11 +124,18 @@ async function main() {
     ),
   );
 
+  // Filter out bumps where `changes` is empty
+  const filteredBumps = bumps.filter(({ changes }) => changes.size > 0);
+  
+  if(filteredBumps.length < 0){
+    core.info('Seems that only devDependencies were added');
+    return;
+  }
   const changesetFilename = await getChangesetFilename();
   const changesetFiles: string[] = [];
 
   // Create a changeset for each of the workspaces in the right place
-  for (const bump of bumps) {
+  for (const bump of filteredBumps) {
     const changesetFilePath = resolvePath(bump.workspace, changesetFilename);
     changesetFiles.push(changesetFilePath);
 

--- a/renovate-changesets/index.ts
+++ b/renovate-changesets/index.ts
@@ -17,7 +17,10 @@ async function main() {
     required: false,
   });
 
-  const includeDevDependencies = core.getBooleanInput('includeDevDependencies', { required: false });
+  const excludeDevDependencies = core.getBooleanInput(
+    'excludeDevDependencies',
+    { required: false },
+  );
 
   const branchName = await getBranchName();
 
@@ -115,7 +118,10 @@ async function main() {
   const bumps = await Promise.all(
     Array.from(changedPackageJsons.entries()).map(
       async ([workspace, packages]) => {
-        const changes = await getBumps(packages.map(p => p.localPath), includeDevDependencies);
+        const changes = await getBumps(
+          packages.map(p => p.localPath),
+          excludeDevDependencies,
+        );
 
         return {
           workspace,
@@ -129,7 +135,8 @@ async function main() {
   // Filter out bumps where `changes` is empty
   const filteredBumps = bumps.filter(({ changes }) => changes.size > 0);
 
-  if (filteredBumps.length < 0) {
+  // filteredBumps can be empty if all changes in package.json are related to devDependencies and excludeDevDependencies is false
+  if (filteredBumps.length === 0) {
     core.info('Seems that only devDependencies were added');
     return;
   }

--- a/renovate-changesets/index.ts
+++ b/renovate-changesets/index.ts
@@ -17,6 +17,8 @@ async function main() {
     required: false,
   });
 
+  const includeDevDependencies = core.getBooleanInput('includeDevDependencies', { required: false });
+
   const branchName = await getBranchName();
 
   if (!branchName.startsWith('renovate/')) {
@@ -113,7 +115,7 @@ async function main() {
   const bumps = await Promise.all(
     Array.from(changedPackageJsons.entries()).map(
       async ([workspace, packages]) => {
-        const changes = await getBumps(packages.map(p => p.localPath));
+        const changes = await getBumps(packages.map(p => p.localPath), includeDevDependencies);
 
         return {
           workspace,
@@ -126,8 +128,8 @@ async function main() {
 
   // Filter out bumps where `changes` is empty
   const filteredBumps = bumps.filter(({ changes }) => changes.size > 0);
-  
-  if(filteredBumps.length < 0){
+
+  if (filteredBumps.length < 0) {
     core.info('Seems that only devDependencies were added');
     return;
   }

--- a/renovate-changesets/renovateChangesets.ts
+++ b/renovate-changesets/renovateChangesets.ts
@@ -57,7 +57,10 @@ export const getChangedFiles = async () => {
   return diffOutput.stdout.split('\n');
 };
 
-export async function getBumps(files: string[], includeDevDependencies: boolean) {
+export async function getBumps(
+  files: string[],
+  excludeDevDependencies: boolean,
+) {
   const bumps = new Map();
   for (const file of files) {
     const { stdout: changes } = await getExecOutput('git', ['show', file]);
@@ -78,7 +81,13 @@ export async function getBumps(files: string[], includeDevDependencies: boolean)
         const deps = match[0].replace(/"/g, '');
         const depsVersion = match[1].replace(/"/g, '');
 
-        if (dependencies[deps] || (includeDevDependencies && devDependencies[deps])) {
+        // If the dependency exists in regular dependencies
+        if (dependencies[deps]) {
+          bumps.set(deps, depsVersion);
+        }
+
+        // If it's a devDependency and we're not excluding them
+        if (!excludeDevDependencies && devDependencies[deps]) {
           bumps.set(deps, depsVersion);
         }
       }


### PR DESCRIPTION
This PR updates the `getBumps` function to skip changes that only involve devDependencies, preventing renovate-changesets from being generated for them.

Fixes: https://github.com/backstage/community-plugins/issues/942