### PR TITLE
chore: add a note about documentation to changesets

### DIFF
--- a/changeset-feedback/generateFeedback.ts
+++ b/changeset-feedback/generateFeedback.ts
@@ -211,6 +211,14 @@ export function formatSummary(
 
   let output = '';
 
+  if (
+    changedPackages.length > 0 &&
+    changesets.some(e => [...e.bumps.values()].some(e => e !== 'patch'))
+  ) {
+    output += `> [!IMPORTANT]
+> This PR includes changes that affect public-facing API. Please ensure you are adding/updating documentation for new features or behavior.`;
+  }
+
   output += formatSection(
     `## Missing Changesets
 


### PR DESCRIPTION
From discussion in the docs SIG, adding a note about documentation updates when touching minor version packages. 