### PR TITLE
Upgrade to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
 
     env:
       CI: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: run tests

--- a/.github/workflows/pr-review-comment-trigger.yaml
+++ b/.github/workflows/pr-review-comment-trigger.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr_number-${{ github.event.pull_request.number }}
           path: pr/

--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -16,7 +16,7 @@ jobs:
       # Inspired by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: Read PR Number
         id: pr-number
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -31,5 +31,5 @@ inputs:
     required: true
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/cron/action.yml
+++ b/cron/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: true
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/issue-sync/action.yml
+++ b/issue-sync/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: false
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/pr-sync/action.yml
+++ b/pr-sync/action.yml
@@ -27,5 +27,5 @@ inputs:
     required: false
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/re-review/action.yml
+++ b/re-review/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: true
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/renovate-changesets/action.yaml
+++ b/renovate-changesets/action.yaml
@@ -8,5 +8,5 @@ inputs:
 
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js


### PR DESCRIPTION
This pull request updates the Node.js version used across GitHub Actions workflows and custom actions from Node 20 to Node 24, and also upgrades several GitHub Actions to their latest major versions.

This is in line with the "stock" actions upgrade process https://github.com/actions/checkout/releases