### PR TITLE
Pin cache action version in action.yml to a hash instead of version

### DIFF
--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -17,7 +17,7 @@ runs:
     # Cache every node_modules folder inside the monorepo
     - name: cache all node_modules
       id: cache-modules
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: '**/node_modules'
         # We use both yarn.lock and package.json as cache keys to ensure that
@@ -34,7 +34,7 @@ runs:
       shell: bash
 
     - name: cache global yarn cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: steps.cache-modules.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}


### PR DESCRIPTION
In order to address the trivy security incident we at INGKA hardened our policies and require to pin the full hash of the actions we use and since `yarn-install` still uses version instead of a hash reference it is breaking some of our internal pipelines.

We already issued a local fix but it would be great if we can propagate an upstream fix as well.