### PR TITLE
chore(yarn-install): upgraded `actions/cache` action, deduped yarn version check

### DIFF
--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -31,12 +31,12 @@ runs:
       id: yarn-cache
       if: steps.cache-modules.outputs.cache-hit != 'true'
       run: |
-        if [[ "$(yarn --version)" =~ "1.*" ]]; then
+        if [[ "$(yarn --version)" =~ ^1\\. ]]; then
           dir="$(yarn cache dir)"
-          flag='--fronzen-lockfile'
+          flag='--frozen-lockfile'
         else
           dir="$(yarn config get cacheFolder)"
-          flag='--frozen-lockfile'
+          flag='--immutable'
         fi
 
         {

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -17,7 +17,7 @@ runs:
     # Cache every node_modules folder inside the monorepo
     - name: cache all node_modules
       id: cache-modules
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # 6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: '**/node_modules'
         # We use both yarn.lock and package.json as cache keys to ensure that
@@ -46,7 +46,7 @@ runs:
       shell: bash
 
     - name: cache global yarn cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # 6.1.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       if: steps.cache-modules.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -31,7 +31,7 @@ runs:
       id: yarn-cache
       if: steps.cache-modules.outputs.cache-hit != 'true'
       run: |
-        if [[ "$(yarn --version)" =~ ^1\\. ]]; then
+        if [[ "$(yarn --version)" =~ ^1\. ]]; then
           dir="$(yarn cache dir)"
           flag='--frozen-lockfile'
         else

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -12,12 +12,12 @@ outputs:
     description: The location of the global yarn cache
     value: ${{ steps.yarn-cache.outputs.dir }}
 runs:
-  using: 'composite'
+  using: composite
   steps:
     # Cache every node_modules folder inside the monorepo
     - name: cache all node_modules
       id: cache-modules
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # 6.1.0
       with:
         path: '**/node_modules'
         # We use both yarn.lock and package.json as cache keys to ensure that
@@ -30,11 +30,23 @@ runs:
     - name: find location of global yarn cache
       id: yarn-cache
       if: steps.cache-modules.outputs.cache-hit != 'true'
-      run: echo "dir=$([[ "$(yarn --version)" =~ "1.*" ]] && yarn cache dir || yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      run: |
+        if [[ "$(yarn --version)" =~ "1.*" ]]; then
+          dir="$(yarn cache dir)"
+          flag='--fronzen-lockfile'
+        else
+          dir="$(yarn config get cacheFolder)"
+          flag='--frozen-lockfile'
+        fi
+
+        {
+          echo dir="$dir"
+          echo install-flag="$flag"
+        } >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: cache global yarn cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # 6.1.0
       if: steps.cache-modules.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}
@@ -43,6 +55,8 @@ runs:
           ${{ inputs.cache-prefix }}-yarn-
 
     - name: yarn install
+      env:
+        YARN_INSTALL_FLAG: ${{ steps.yarn-cache.outputs.install-flag }}
       if: steps.cache-modules.outputs.cache-hit != 'true'
-      run: '[[ "$(yarn --version)" =~ "1.*" ]] && yarn install --frozen-lockfile || yarn install --immutable'
+      run: yarn install "$YARN_INSTALL_FLAG"
       shell: bash


### PR DESCRIPTION
* Upgraded `actions/cache` to the latest (`v6.1.0`) 
    This version was released June 26.
* Reduced `yarn` version checks to a single invocation that sets the appropriate variables for future steps


## Motivation

Node `v20` is deprecated. This will get rid of some of the following warnings:

<img width="1682" height="547" alt="2026-08-06_08-52" src="https://github.com/user-attachments/assets/4e8a4d15-7b65-4324-aee1-e70572740789" />
