### PR TITLE
chore(pr-sync) - Updated action to run using Node `v24`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,22 +2,28 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [20.x]
-
-    env:
-      CI: true
+        node-version:
+          - 20.x
+          - 24.x
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: run tests
         run: yarn test

--- a/pr-sync/action.yml
+++ b/pr-sync/action.yml
@@ -27,5 +27,5 @@ inputs:
     required: false
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js


### PR DESCRIPTION
* Added Node `v24` to the CI testing matrix
* Updated some core action (`actions/*`) versions
* Switched action to use `node24`
    This will get rid of Node `v20` deprecation warnings.
* Added some security-related things to the CI workflow (`permissions`, disabled `persist-credentials`)

> [!NOTE]
>
> There's an unrelated test that is failing locally that I will fix in a separate PR.