### PR TITLE
chore: fixed code logic (timezones :shrug:)

### DIFF
--- a/cron/mergeRenovatePRs.test.ts
+++ b/cron/mergeRenovatePRs.test.ts
@@ -96,7 +96,19 @@ describe('mergeRenovatePRs', () => {
   });
 
   it('should not merge on Tuesdays', async () => {
-    jest.useFakeTimers({ now: new Date('2022-06-28T00:00:00.000Z') });
+    // NOTE: This test would previously pass/fail based on the phystical
+    // location where it was run.
+    // Example: Midnight UTC is 7pm CDT on the previous day
+    //
+    // To fix this, we adjust the generated date by the timezone offset
+    const desiredDate = new Date('2022-06-28T00:00:00.000Z');
+    const ONE_EARTH_MINUTE = 60_000;
+    jest.useFakeTimers({
+      now: new Date(
+        desiredDate.getTime() +
+          desiredDate.getTimezoneOffset() * ONE_EARTH_MINUTE,
+      ),
+    });
 
     await mergeRenovatePRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();

--- a/cron/mergeRenovatePRs.test.ts
+++ b/cron/mergeRenovatePRs.test.ts
@@ -96,19 +96,7 @@ describe('mergeRenovatePRs', () => {
   });
 
   it('should not merge on Tuesdays', async () => {
-    // NOTE: This test would previously pass/fail based on the phystical
-    // location where it was run.
-    // Example: Midnight UTC is 7pm CDT on the previous day
-    //
-    // To fix this, we adjust the generated date by the timezone offset
-    const desiredDate = new Date('2022-06-28T00:00:00.000Z');
-    const ONE_EARTH_MINUTE = 60_000;
-    jest.useFakeTimers({
-      now: new Date(
-        desiredDate.getTime() +
-          desiredDate.getTimezoneOffset() * ONE_EARTH_MINUTE,
-      ),
-    });
+    jest.useFakeTimers({ now: new Date('2022-06-28T00:00:00.000Z') });
 
     await mergeRenovatePRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();

--- a/cron/mergeRenovatePRs.ts
+++ b/cron/mergeRenovatePRs.ts
@@ -11,7 +11,7 @@ export async function mergeRenovatePRs(
   const { owner, repo } = repoInfo;
 
   const date = new Date();
-  if (date.getDay() === 2) {
+  if (date.getUTCDay() === 2) {
     log('Skipping auto merge because Tuesday is release day');
     return;
   }


### PR DESCRIPTION
This test fails consistently locally. There seems to be a logic issue with respect to time zones.

## Details

The test expects to run on midnight Tuesday UTC (`2022-06-28`) using a fake timer. However it was actually generating a date that was relative to the local time. So for me, midnight UTC is 7pm CDT on the previous day (`06-27` which is a Monday) so the test would fail. I patched this by always adjusting the time based on the timezone offset.

## Verification

From a very basic set of local testing, it seems to pass consistently (where the `main` branch fails):

```shell
➜  backstage-actions git:(cron/fix-test) for x in America/Los_Angeles America/New_York Etc/GMT Africa/Nairobi Asia/Tokyo Pacific/Kiritimati; do if env TZ="$x" yarn test cron/mergeRenovatePRs.test.ts &> /dev/null; then outcome='passed'; else outcome='FAILED'; fi; printf '%-20s -> %s\n' "$x" "$outcome"; done
America/Los_Angeles  -> passed
America/New_York     -> passed
Etc/GMT              -> passed
Africa/Nairobi       -> passed
Asia/Tokyo           -> passed
Pacific/Kiritimati   -> passed
➜  backstage-actions git:(cron/fix-test) gcm
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
➜  backstage-actions git:(main) for x in America/Los_Angeles America/New_York Etc/GMT Africa/Nairobi Asia/Tokyo Pacific/Kiritimati; do if env TZ="$x" yarn test cron/mergeRenovatePRs.test.ts &> /dev/null; then outcome='passed'; else outcome='FAILED'; fi; printf '%-20s -> %s\n' "$x" "$outcome"; done
America/Los_Angeles  -> FAILED
America/New_York     -> FAILED
Etc/GMT              -> passed
Africa/Nairobi       -> passed
Asia/Tokyo           -> passed
Pacific/Kiritimati   -> passed
```

EDIT: I originally thought the test was bad, but the code was actually flawed. So I just fixed that instead.