### PR TITLE
chore: migrate JavaScript actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,26 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 24.x]
 
     env:
       CI: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node-version }}
       - name: run tests

--- a/changeset-feedback/action.yaml
+++ b/changeset-feedback/action.yaml
@@ -31,5 +31,5 @@ inputs:
     required: true
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/cron/action.yml
+++ b/cron/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: true
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/issue-sync/action.yml
+++ b/issue-sync/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: false
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/pr-sync/action.yml
+++ b/pr-sync/action.yml
@@ -27,5 +27,5 @@ inputs:
     required: false
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/re-review/action.yml
+++ b/re-review/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: true
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js

--- a/renovate-changesets/action.yaml
+++ b/renovate-changesets/action.yaml
@@ -8,5 +8,5 @@ inputs:
 
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: ./entry.js


### PR DESCRIPTION
## Summary

- migrate the six remaining JavaScript actions from the Node 20 runtime to Node 24
- retain Node 20 as a comparison leg while adding Node 24 to CI
- update CI to immutable Node 24-capable `checkout` and `setup-node` v7 revisions
- restrict CI permissions to read-only contents and disable persisted checkout credentials

`pr-automation` already targets Node 24 after #187. `yarn-install` is a composite action and is intentionally unchanged.

## Consumer impact

The intended consumers are `backstage/backstage` and `backstage/community-plugins`, both on GitHub-hosted runners. Current active usage covers `changeset-feedback`, `cron`, `pr-automation`, and `pr-sync`; migrating the remaining dormant JavaScript manifests keeps the next release internally consistent.

This PR intentionally leaves dependency modernization and composite-action changes for separate follow-ups. The existing Octokit stack emits Node's `DEP0040` warning for its transitive `punycode` dependency under Node 24, but the warning is non-fatal and the full suite passes.

This supersedes the runtime-manifest scope proposed in #166 and the `pr-sync` runtime scope in #186.

## Validation

- Node 20.20.2: 23 suites, 121 tests passed
- Node 24.16.0: 23 suites, 121 tests passed
- all eight action manifests and the CI workflow parse as YAML
- all JavaScript action manifests resolve to `node24`; `yarn-install` remains `composite`
