### PR TITLE
fix: preserve errors with non-string codes

### DIFF
--- a/lib/withRetry.test.ts
+++ b/lib/withRetry.test.ts
@@ -60,6 +60,16 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves errors with non-string codes', async () => {
+    const forbidden = Object.assign(new Error('Forbidden'), { code: 403 });
+    const fn = jest.fn<() => Promise<string>>().mockRejectedValue(forbidden);
+
+    await expect(
+      withRetry(fn, { maxAttempts: 5, initialDelayMs: 1 }),
+    ).rejects.toBe(forbidden);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
   it('exhausts all attempts and re-throws the last transient error', async () => {
     const hangUp = new Error('socket hang up');
     const fn = jest.fn<() => Promise<string>>().mockRejectedValue(hangUp);

--- a/lib/withRetry.ts
+++ b/lib/withRetry.ts
@@ -21,8 +21,10 @@ export interface RetryOptions {
 function isTransientError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const msg = error.message;
-  const code = (error as NodeJS.ErrnoException).code ?? '';
-  return RETRYABLE_PATTERNS.some(p => msg.includes(p) || code.includes(p));
+  const code = (error as NodeJS.ErrnoException).code;
+  return RETRYABLE_PATTERNS.some(
+    p => msg.includes(p) || (typeof code === 'string' && code.includes(p)),
+  );
 }
 
 /**


### PR DESCRIPTION
## Description

Prevent retry classification from replacing the original error with a `TypeError` when an API error exposes a non-string `code`. Non-string codes are treated as non-transient, while existing string network-code matching remains unchanged.

Includes a regression test that verifies the original error is rethrown without retrying.

## Testing

- `CI=1 yarn test --runInBand`