### PR TITLE
chore: refresh official workflow actions

### DIFF
--- a/.github/workflows/pr-review-comment-trigger.yaml
+++ b/.github/workflows/pr-review-comment-trigger.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir -p ./pr
           echo $PR_NUMBER > ./pr/pr_number
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr_number-${{ github.event.pull_request.number }}
           path: pr/

--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -16,7 +16,7 @@ jobs:
       # Inspired by https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: Read PR Number
         id: pr-number
-        uses: actions/github-script@v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

- upgrade actions/upload-artifact from v3 to v7.0.1, pinned to its immutable release SHA
- upgrade actions/github-script from v6 to v9.0.0, pinned to its immutable release SHA
- move the remaining GitHub-maintained workflow actions in this repository onto Node 24

## Compatibility

- the artifact workflow performs one upload with a unique name, so the v4+ immutability and multiple-upload changes do not affect it
- the github-script snippet uses the injected github, context, and core objects only; it does not use the ESM require pattern or redeclare getOctokit affected by v9
- self-references to backstage/actions remain unchanged and can move after the next repository release

## Validation

- yarn test (23 suites, 122 tests)
- parsed all workflow YAML files with Psych
- git diff --check
- independently reviewed with no findings