### PR TITLE
fix: avoid Yarn configuration env for install flag

### DIFF
--- a/yarn-install/action.test.ts
+++ b/yarn-install/action.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from '@jest/globals';
+
+describe('yarn-install action', () => {
+  it('does not pass the install flag through Yarn configuration', () => {
+    const action = readFileSync(join(__dirname, 'action.yml'), 'utf8');
+
+    expect(action).not.toMatch(/^\s+YARN_[A-Z_]*INSTALL_FLAG:/m);
+    expect(action).toContain(
+      'INSTALL_FLAG: ${{ steps.yarn-cache.outputs.install-flag }}',
+    );
+    expect(action).toContain('run: yarn install "$INSTALL_FLAG"');
+  });
+});

--- a/yarn-install/action.yml
+++ b/yarn-install/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: yarn install
       env:
-        YARN_INSTALL_FLAG: ${{ steps.yarn-cache.outputs.install-flag }}
+        INSTALL_FLAG: ${{ steps.yarn-cache.outputs.install-flag }}
       if: steps.cache-modules.outputs.cache-hit != 'true'
-      run: yarn install "$YARN_INSTALL_FLAG"
+      run: yarn install "$INSTALL_FLAG"
       shell: bash


### PR DESCRIPTION
Fixes the `yarn-install` regression released in v0.7.9.

Yarn Berry interprets every `YARN_*` environment variable as a configuration setting. Passing the selected install argument through `YARN_INSTALL_FLAG` therefore makes Yarn read an unsupported `installFlag` setting and fail before installation.

This renames the action-local variable to `INSTALL_FLAG`, preserving the existing Yarn 1 `--frozen-lockfile` and modern Yarn `--immutable` selection and quoting. It also adds a focused regression test preventing the install flag from being transported through the Yarn configuration namespace.

Validation:

- `yarn jest yarn-install/action.test.ts --runInBand`
- `yarn test --runInBand` (24 suites, 123 tests)
- `yarn-install/action.yml` YAML parse
- direct confirmation that Yarn accepts `INSTALL_FLAG=--immutable` without treating it as configuration