### PR TITLE
chore: use current action releases in workflows

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: backstage/actions/cron@v0.6.2
+      - uses: backstage/actions/cron@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -9,4 +9,4 @@ jobs:
 
     steps:
       - name: Sync Issues
-        uses: backstage/actions/issue-sync@v0.6.2
+        uses: backstage/actions/issue-sync@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10

--- a/.github/workflows/pr-review-comment.yaml
+++ b/.github/workflows/pr-review-comment.yaml
@@ -33,7 +33,7 @@ jobs:
             const prNumber = artifact.name.slice('pr_number-'.length)
             core.setOutput('pr-number', prNumber);
 
-      - uses: backstage/actions/re-review@v0.6.2
+      - uses: backstage/actions/re-review@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
         with:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event.pull_request || github.event.issue.pull_request }}
 
     steps:
-      - uses: backstage/actions/pr-sync@v0.6.2
+      - uses: backstage/actions/pr-sync@0d281eb2e96927466db49d4cd01d52b14809a66b # v0.7.10
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN  }}
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}


### PR DESCRIPTION
## Summary

- pin the repository workflows to the immutable v0.7.10 release commit
- move self-use of cron, issue-sync, pr-sync, and re-review from the old v0.6.2 Node 16 builds to their Node 24 builds

## Testing

- `yarn test` (123 tests)
- parsed all four edited workflow files as YAML