### PR TITLE
Support Dependabot in dependency PR automerge

### DIFF
--- a/cron/index.ts
+++ b/cron/index.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { verifyDCO } from './verifyDCO';
-import { mergeRenovatePRs } from './mergeRenovatePRs';
+import { mergeDependencyPRs } from './mergeDependencyPRs';
 import { mkLog } from '../lib/mkLog';
 import { createAppClient } from '../lib/createAppClient';
 
@@ -14,7 +14,7 @@ async function main() {
 
   await Promise.all([
     verifyDCO(client, repoInfo, mkLog('verify-dco')),
-    mergeRenovatePRs(client, repoInfo, mkLog('merge-renovate-prs')),
+    mergeDependencyPRs(client, repoInfo, mkLog('merge-dependency-prs')),
   ]);
 }
 

--- a/cron/mergeDependencyPRs.test.ts
+++ b/cron/mergeDependencyPRs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals';
 import { getOctokit } from '@actions/github';
-import { mergeRenovatePRs } from './mergeRenovatePRs';
+import { mergeDependencyPRs } from './mergeDependencyPRs';
 
 type Octokit = ReturnType<typeof getOctokit>;
 
@@ -19,7 +19,7 @@ const repoInfo = {
   repo: 'le-repo',
 };
 
-describe('mergeRenovatePRs', () => {
+describe('mergeDependencyPRs', () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
@@ -53,7 +53,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).toHaveBeenCalledWith({
       owner: 'le-owner',
       repo: 'le-repo',
@@ -62,7 +62,101 @@ describe('mergeRenovatePRs', () => {
     expect(log).toBeCalledWith('Merging #1 - test-pr');
   });
 
-  it('should not merge non-renovate PRs', async () => {
+  it('should merge green dependabot PRs', async () => {
+    jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
+
+    mockClient.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequests: {
+          nodes: [
+            {
+              title: 'test-pr',
+              number: 1,
+              author: { login: 'dependabot' },
+              mergeable: 'MERGEABLE',
+              reviewDecision: 'APPROVED',
+              changedFiles: 1,
+              files: {
+                nodes: [{ path: 'yarn.lock' }],
+              },
+              commits: {
+                nodes: [
+                  { commit: { statusCheckRollup: { state: 'SUCCESS' } } },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await mergeDependencyPRs(client, repoInfo, log, 0);
+    expect(mockClient.rest.pulls.merge).toHaveBeenCalledWith({
+      owner: 'le-owner',
+      repo: 'le-repo',
+      pull_number: 1,
+    });
+    expect(log).toBeCalledWith('Merging #1 - test-pr');
+  });
+
+  it('should merge PRs from later pages', async () => {
+    jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
+
+    mockClient.graphql
+      .mockResolvedValueOnce({
+        repository: {
+          pullRequests: {
+            pageInfo: {
+              hasNextPage: true,
+              endCursor: 'first-page',
+            },
+            nodes: [],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        repository: {
+          pullRequests: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            nodes: [
+              {
+                title: 'test-pr',
+                number: 1,
+                author: { login: 'renovate' },
+                mergeable: 'MERGEABLE',
+                reviewDecision: 'APPROVED',
+                changedFiles: 1,
+                files: {
+                  nodes: [{ path: 'yarn.lock' }],
+                },
+                commits: {
+                  nodes: [
+                    { commit: { statusCheckRollup: { state: 'SUCCESS' } } },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      });
+
+    await mergeDependencyPRs(client, repoInfo, log, 0);
+    expect(mockClient.graphql).toHaveBeenLastCalledWith(expect.any(String), {
+      owner: 'le-owner',
+      repo: 'le-repo',
+      after: 'first-page',
+    });
+    expect(mockClient.rest.pulls.merge).toHaveBeenCalledWith({
+      owner: 'le-owner',
+      repo: 'le-repo',
+      pull_number: 1,
+    });
+  });
+
+  it('should not merge PRs from unknown authors', async () => {
     jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
 
     mockClient.graphql.mockResolvedValueOnce({
@@ -90,7 +184,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalledWith();
     expect(log).toBeCalledWith('No mergeable PRs');
   });
@@ -98,7 +192,7 @@ describe('mergeRenovatePRs', () => {
   it('should not merge on Tuesdays', async () => {
     jest.useFakeTimers({ now: new Date('2022-06-28T00:00:00.000Z') });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
     expect(log).toBeCalledWith(
       'Skipping auto merge because Tuesday is release day',
@@ -133,7 +227,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
     expect(log).toBeCalledWith('No mergeable PRs');
   });
@@ -166,7 +260,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
     expect(log).toBeCalledWith('No mergeable PRs');
   });
@@ -199,7 +293,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
     expect(log).toBeCalledWith('No mergeable PRs');
   });
@@ -232,7 +326,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
     expect(log).toBeCalledWith('No mergeable PRs');
   });
@@ -265,7 +359,7 @@ describe('mergeRenovatePRs', () => {
       },
     });
 
-    await mergeRenovatePRs(client, repoInfo, log, 0);
+    await mergeDependencyPRs(client, repoInfo, log, 0);
     expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
     expect(log).toBeCalledWith('No mergeable PRs');
   });

--- a/cron/mergeDependencyPRs.ts
+++ b/cron/mergeDependencyPRs.ts
@@ -2,7 +2,13 @@ import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { Repository } from '@octokit/graphql-schema';
 
-export async function mergeRenovatePRs(
+type PullRequest = NonNullable<
+  NonNullable<Repository['pullRequests']['nodes']>[number]
+>;
+
+const AUTOMERGE_AUTHORS = new Set(['dependabot', 'renovate']);
+
+export async function mergeDependencyPRs(
   client: ReturnType<typeof github.getOctokit>,
   repoInfo: { owner: string; repo: string },
   log = core.info,
@@ -16,10 +22,18 @@ export async function mergeRenovatePRs(
     return;
   }
 
-  const data = await client.graphql<{ repository?: Repository }>(
-    `query ($owner: String!, $repo: String!) {
+  const pullRequests = [];
+  let after: string | null | undefined;
+
+  do {
+    const data = await client.graphql<{ repository?: Repository }>(
+      `query ($owner: String!, $repo: String!, $after: String) {
       repository(owner: $owner, name: $repo) {
-        pullRequests(labels: ["dependencies"], last: 10, states: [OPEN]) {
+        pullRequests(labels: ["dependencies"], first: 100, after: $after, states: [OPEN]) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           nodes {
             title
             author {
@@ -54,21 +68,31 @@ export async function mergeRenovatePRs(
         }
       }
     }`,
-    { owner, repo },
-  );
-  if (!data.repository) {
-    throw new Error(`No such repository ${owner}/${repo}`);
-  }
+      { owner, repo, after },
+    );
+    if (!data.repository) {
+      throw new Error(`No such repository ${owner}/${repo}`);
+    }
 
-  const mergeable = data.repository.pullRequests.nodes?.filter(
-    pr =>
-      pr &&
-      pr.author?.login === 'renovate' &&
-      pr.mergeable === 'MERGEABLE' &&
-      pr.changedFiles === 1 &&
-      pr.files?.nodes?.[0]?.path.split('/').slice(-1)[0] === 'yarn.lock' &&
-      pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.state === 'SUCCESS' &&
-      pr.reviewDecision === 'APPROVED',
+    pullRequests.push(...(data.repository.pullRequests.nodes ?? []));
+    after = data.repository.pullRequests.pageInfo?.hasNextPage
+      ? data.repository.pullRequests.pageInfo.endCursor
+      : undefined;
+  } while (after);
+
+  const mergeable = pullRequests.filter(
+    (pr): pr is PullRequest =>
+      Boolean(
+        pr &&
+          pr.author?.login &&
+          AUTOMERGE_AUTHORS.has(pr.author.login) &&
+          pr.mergeable === 'MERGEABLE' &&
+          pr.changedFiles === 1 &&
+          pr.files?.nodes?.[0]?.path.split('/').slice(-1)[0] === 'yarn.lock' &&
+          pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.state ===
+            'SUCCESS' &&
+          pr.reviewDecision === 'APPROVED',
+      ),
   );
   if (!mergeable?.length) {
     log('No mergeable PRs');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Extends the scheduled dependency PR automerge job to handle both Renovate and Dependabot PRs, while keeping the existing safety predicates: dependency label, single changed file, yarn.lock-only, mergeable, green checks, approved, and no Tuesday release-day merging.

Also changes the dependency PR lookup from the latest 10 matching PRs to paginated first:100 reads so older eligible dependency PRs are not skipped just because newer dependency PRs are not mergeable.

Checklist:
- Added tests for changed functionality
- Ran yarn test