### PR TITLE
Allow dependency merges with a separate token

### DIFF
--- a/cron/action.yml
+++ b/cron/action.yml
@@ -10,6 +10,9 @@ inputs:
   installation-id:
     description: The Installation ID of the GitHub App to use for authentication
     required: true
+  merge-token:
+    description: A GitHub token to use for merging dependency pull requests
+    required: false
 outputs: {}
 runs:
   using: node24

--- a/cron/index.ts
+++ b/cron/index.ts
@@ -9,12 +9,20 @@ async function main() {
   core.info(`Running cron!`);
 
   const client = createAppClient();
+  const mergeToken = core.getInput('merge-token');
+  const mergeClient = mergeToken ? github.getOctokit(mergeToken) : client;
 
   const repoInfo = github.context.repo;
 
   await Promise.all([
     verifyDCO(client, repoInfo, mkLog('verify-dco')),
-    mergeDependencyPRs(client, repoInfo, mkLog('merge-dependency-prs')),
+    mergeDependencyPRs(
+      client,
+      repoInfo,
+      mkLog('merge-dependency-prs'),
+      undefined,
+      mergeClient,
+    ),
   ]);
 }
 

--- a/cron/mergeDependencyPRs.test.ts
+++ b/cron/mergeDependencyPRs.test.ts
@@ -99,6 +99,52 @@ describe('mergeDependencyPRs', () => {
     expect(log).toBeCalledWith('Merging #1 - test-pr');
   });
 
+  it('should use a separate merge client when provided', async () => {
+    jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
+
+    const mergeClient = {
+      rest: {
+        pulls: {
+          merge: jest.fn<Octokit['rest']['pulls']['merge']>(),
+        },
+      },
+    } as unknown as Octokit;
+
+    mockClient.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequests: {
+          nodes: [
+            {
+              title: 'test-pr',
+              number: 1,
+              author: { login: 'dependabot' },
+              mergeable: 'MERGEABLE',
+              reviewDecision: 'APPROVED',
+              changedFiles: 1,
+              files: {
+                nodes: [{ path: 'yarn.lock' }],
+              },
+              commits: {
+                nodes: [
+                  { commit: { statusCheckRollup: { state: 'SUCCESS' } } },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await mergeDependencyPRs(client, repoInfo, log, 0, mergeClient);
+
+    expect(mockClient.rest.pulls.merge).not.toHaveBeenCalled();
+    expect(mergeClient.rest.pulls.merge).toHaveBeenCalledWith({
+      owner: 'le-owner',
+      repo: 'le-repo',
+      pull_number: 1,
+    });
+  });
+
   it('should merge PRs from later pages', async () => {
     jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
 

--- a/cron/mergeDependencyPRs.ts
+++ b/cron/mergeDependencyPRs.ts
@@ -13,6 +13,7 @@ export async function mergeDependencyPRs(
   repoInfo: { owner: string; repo: string },
   log = core.info,
   waitTimeMs = 2000,
+  mergeClient = client,
 ) {
   const { owner, repo } = repoInfo;
 
@@ -104,7 +105,7 @@ export async function mergeDependencyPRs(
       continue;
     }
     log(`Merging #${pr.number} - ${pr.title}`);
-    await client.rest.pulls.merge({
+    await mergeClient.rest.pulls.merge({
       owner,
       repo,
       pull_number: pr.number,

--- a/lib/withRetry.test.ts
+++ b/lib/withRetry.test.ts
@@ -70,6 +70,25 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('does not read deprecated Octokit request error codes', async () => {
+    const requestError = Object.assign(new Error('Forbidden'), {
+      status: 403,
+    });
+    const getCode = jest.fn(() => 403);
+
+    Object.defineProperty(requestError, 'code', {
+      get: getCode,
+    });
+
+    const fn = jest.fn<() => Promise<string>>().mockRejectedValue(requestError);
+
+    await expect(
+      withRetry(fn, { maxAttempts: 5, initialDelayMs: 1 }),
+    ).rejects.toBe(requestError);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(getCode).not.toHaveBeenCalled();
+  });
+
   it('exhausts all attempts and re-throws the last transient error', async () => {
     const hangUp = new Error('socket hang up');
     const fn = jest.fn<() => Promise<string>>().mockRejectedValue(hangUp);

--- a/lib/withRetry.ts
+++ b/lib/withRetry.ts
@@ -21,7 +21,8 @@ export interface RetryOptions {
 function isTransientError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const msg = error.message;
-  const code = (error as NodeJS.ErrnoException).code;
+  const code =
+    'status' in error ? undefined : (error as NodeJS.ErrnoException).code;
   return RETRYABLE_PATTERNS.some(
     p => msg.includes(p) || (typeof code === 'string' && code.includes(p)),
   );


### PR DESCRIPTION
## Summary
- add an optional merge-token input for cron
- use the merge token for dependency PR merges when provided
- avoid reading deprecated Octokit request error code values

## Testing
- yarn test
- yarn tsc --noEmit fails on existing unrelated type errors in lib/createAppClient.ts and pr-automation/applyOutput.ts