### PR TITLE
fix: continue after dependency merge conflicts

### DIFF
--- a/cron/mergeDependencyPRs.test.ts
+++ b/cron/mergeDependencyPRs.test.ts
@@ -99,6 +99,70 @@ describe('mergeDependencyPRs', () => {
     expect(log).toBeCalledWith('Merging #1 - test-pr');
   });
 
+  it('should continue merging after a pull request develops merge conflicts', async () => {
+    jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
+
+    mockClient.graphql.mockResolvedValueOnce({
+      repository: {
+        pullRequests: {
+          nodes: [
+            {
+              title: 'conflicting-pr',
+              number: 1,
+              author: { login: 'dependabot' },
+              mergeable: 'MERGEABLE',
+              reviewDecision: 'APPROVED',
+              changedFiles: 1,
+              files: {
+                nodes: [{ path: 'yarn.lock' }],
+              },
+              commits: {
+                nodes: [
+                  { commit: { statusCheckRollup: { state: 'SUCCESS' } } },
+                ],
+              },
+            },
+            {
+              title: 'mergeable-pr',
+              number: 2,
+              author: { login: 'dependabot' },
+              mergeable: 'MERGEABLE',
+              reviewDecision: 'APPROVED',
+              changedFiles: 1,
+              files: {
+                nodes: [{ path: 'yarn.lock' }],
+              },
+              commits: {
+                nodes: [
+                  { commit: { statusCheckRollup: { state: 'SUCCESS' } } },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+    mockClient.rest.pulls.merge
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Pull Request has merge conflicts'), {
+          status: 405,
+        }),
+      )
+      .mockResolvedValueOnce({} as never);
+
+    await mergeDependencyPRs(client, repoInfo, log, 0);
+
+    expect(mockClient.rest.pulls.merge).toHaveBeenCalledTimes(2);
+    expect(mockClient.rest.pulls.merge).toHaveBeenLastCalledWith({
+      owner: 'le-owner',
+      repo: 'le-repo',
+      pull_number: 2,
+    });
+    expect(log).toHaveBeenCalledWith(
+      'Skipping #1 because it is no longer mergeable: Pull Request has merge conflicts',
+    );
+  });
+
   it('should use a separate merge client when provided', async () => {
     jest.useFakeTimers({ now: new Date('2022-06-27T00:00:00.000Z') });
 

--- a/cron/mergeDependencyPRs.ts
+++ b/cron/mergeDependencyPRs.ts
@@ -105,11 +105,27 @@ export async function mergeDependencyPRs(
       continue;
     }
     log(`Merging #${pr.number} - ${pr.title}`);
-    await mergeClient.rest.pulls.merge({
-      owner,
-      repo,
-      pull_number: pr.number,
-    });
+    try {
+      await mergeClient.rest.pulls.merge({
+        owner,
+        repo,
+        pull_number: pr.number,
+      });
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'status' in error &&
+        error.status === 405
+      ) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(
+          `Skipping #${pr.number} because it is no longer mergeable: ${message}`,
+        );
+        continue;
+      }
+      throw error;
+    }
 
     if (waitTimeMs) {
       await new Promise(r => setTimeout(r, waitTimeMs));


### PR DESCRIPTION
## Summary

- treat a merge-endpoint HTTP 405 as a stale per-PR mergeability result
- log and continue with the rest of the dependency PR batch
- keep unexpected merge failures fatal

The Cron workflow can select several green lockfile PRs at once, but merging an earlier PR can make a later one conflict with the updated base. Previously that expected race aborted the entire batch, as seen in https://github.com/backstage/backstage/actions/runs/34598326644/job/103259265708.

## Testing

- `yarn test --runInBand` (24 suites, 128 tests)
- `git diff --check`